### PR TITLE
Bump pyromod from 2.0.0 to 3.1.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 motor==3.2.0
-pyromod==2.0.0
+pyromod==3.1.6
 oldpyro==0.1.0
 pyrogram==2.0.106
 python-dotenv==1.0.0


### PR DESCRIPTION
Bumps [pyromod]() from 2.0.0 to 3.1.6.

---
updated-dependencies:
- dependency-name: pyromod dependency-type: direct:production update-type: version-update:semver-major ...